### PR TITLE
Fix/wrong permissions for local snapshots

### DIFF
--- a/hornet-private-net/config/config-coo.json
+++ b/hornet-private-net/config/config-coo.json
@@ -36,6 +36,9 @@
   },
   "snapshots": {
     "loadType": "global",
+    "local": {
+      "path": "/app/snapshots/private-tangle/export.bin"
+    },
     "global": {
         "path": "/app/snapshots/private-tangle/snapshot.csv",
         "spentAddressesPaths": [],

--- a/hornet-private-net/config/config-coo.json
+++ b/hornet-private-net/config/config-coo.json
@@ -37,7 +37,7 @@
   "snapshots": {
     "loadType": "global",
     "local": {
-      "path": "/app/snapshots/private-tangle/export.bin"
+      "path": "/app/snapshots/private-tangle/export-coo.bin"
     },
     "global": {
         "path": "/app/snapshots/private-tangle/snapshot.csv",

--- a/hornet-private-net/config/config-node.json
+++ b/hornet-private-net/config/config-node.json
@@ -53,7 +53,7 @@
   "snapshots": {
     "loadType": "global",
     "local": {
-      "path": "/app/snapshots/private-tangle/export.bin"
+      "path": "/app/snapshots/private-tangle/export-node.bin"
     },
     "global": {
         "path": "/app/snapshots/private-tangle/snapshot.csv",

--- a/hornet-private-net/config/config-node.json
+++ b/hornet-private-net/config/config-node.json
@@ -52,6 +52,9 @@
   },
   "snapshots": {
     "loadType": "global",
+    "local": {
+      "path": "/app/snapshots/private-tangle/export.bin"
+    },
     "global": {
         "path": "/app/snapshots/private-tangle/snapshot.csv",
         "spentAddressesPaths": [],

--- a/hornet-private-net/config/config-spammer.json
+++ b/hornet-private-net/config/config-spammer.json
@@ -36,6 +36,9 @@
   },
   "snapshots": {
     "loadType": "global",
+    "local": {
+      "path": "/app/snapshots/private-tangle/export.bin"
+    },
     "global": {
         "path": "/app/snapshots/private-tangle/snapshot.csv",
         "spentAddressesPaths": [],

--- a/hornet-private-net/config/config-spammer.json
+++ b/hornet-private-net/config/config-spammer.json
@@ -37,7 +37,7 @@
   "snapshots": {
     "loadType": "global",
     "local": {
-      "path": "/app/snapshots/private-tangle/export.bin"
+      "path": "/app/snapshots/private-tangle/export-spammer.bin"
     },
     "global": {
         "path": "/app/snapshots/private-tangle/snapshot.csv",

--- a/hornet-private-net/private-tangle.sh
+++ b/hornet-private-net/private-tangle.sh
@@ -104,6 +104,8 @@ volumeSetup () {
   ## Change permissions so that the Tangle data can be written (hornet user)
   ## TODO: Check why on MacOS this cause permission problems
   sudo chown 39999:39999 db/private-tangle 
+  sudo chown 39999:39999 snapshots/private-tangle 
+
 }
 
 startTangle () {


### PR DESCRIPTION
# Description of change

When hornet reaches a checkpoint, the following error shows up in the hornet logs

```
2021-03-16T14:22:44Z	INFO	Snapshot	snapshot/local_snapshot.go:382	creating local snapshot for targetIndex 16764
2021-03-16T14:22:44Z	WARN	Snapshot	snapshot/plugin.go:196	mkdir snapshots/mainnet: permission denied: creating snapshot failed
```

A private tangle shouldn't sync up with the mainnet, but it's part of the database.

A path should be added to the local snapshots that hornet is taking (for recovery purpose when database file crashes). Permissions need to be given to the snapshots/private-tangle folder to write out the file. This problem shows up on the node, coo and spammer hence changes need to be made to the config files of this files.

## Type of change

Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

The snapshots/private-tangle folder permission were changed to enable hornet to write to the folder.

The config file for the  node, spammer and coo, in the snapshots section added the required path. Respectively.

After running the node, coo and spammer till the 100th milestone, the error vanished and instead we have the message

```
2021-03-19T12:18:42Z    INFO    Tangle  tangle/milestones.go:31 Valid milestone detected! Index: 101, Hash: MVQOKZDLAHYIKKZSHSNG9EMVTSDAL9BHIDGPPQBX9SFMWULACQTSOOWXRSZSJPCDUPUVJODNNNRPZB999
2021-03-19T12:18:42Z    INFO    Tangle  tangle/solidifier.go:394        Run solidity check for Milestone (101)...
2021-03-19T12:18:42Z    INFO    Tangle  tangle/solidifier.go:211        Solidifier finished: txs: 0, collect: 0s, solidity 0s, propagation: 0s, total: 0s
2021-03-19T12:18:42Z    INFO    Tangle  tangle/solidifier.go:449        Milestone confirmed (101): txsConfirmed: 4, txsValue: 0, txsZeroValue: 4, txsConflicting: 0, collect: 0s, total: 0s
2021-03-19T12:18:42Z    INFO    Tangle  tangle/solidifier.go:480        New solid milestone: 101, 0.07 TPS, 0.07 CTPS, 100.00% conf.rate
2021-03-19T12:18:42Z    INFO    Snapshot        snapshot/local_snapshot.go:382  creating local snapshot for targetIndex 51
2021-03-19T12:18:42Z    INFO    Snapshot        snapshot/local_snapshot.go:469  created local snapshot for target index 51 (sha256: 21df71b9354b1aabaea02c03218bc1a57f6f66742de1dfc78812c25e57fd1cd2), took 5.937165ms
```
And checking the snapshot folder we see the respective bin files listed

![image](https://user-images.githubusercontent.com/6847405/111779767-92575b00-88c7-11eb-8b44-0860061435ba.png)

## Change checklist

- [x] I have performed a self-review of my own code

