### PR TITLE
Set permissions on snapshot later so that initial address can be gene…

### DIFF
--- a/hornet-private-net/private-tangle.sh
+++ b/hornet-private-net/private-tangle.sh
@@ -104,7 +104,6 @@ volumeSetup () {
   ## Change permissions so that the Tangle data can be written (hornet user)
   ## TODO: Check why on MacOS this cause permission problems
   sudo chown 39999:39999 db/private-tangle 
-  sudo chown 39999:39999 snapshots/private-tangle 
 
 }
 
@@ -118,6 +117,9 @@ startTangle () {
 
   # Initial address for the snapshot
   generateInitialAddress
+
+  # Change permissions for the snapshots 
+  sudo chown 39999:39999 snapshots/private-tangle
 
   setupCoordinator
 


### PR DESCRIPTION
…rated

# Description of change

Sets the permissions on snapshot later so that the address generation and rest of process do not have to be executed as root

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix (a non-breaking change which fixes an issue)


## How the change has been tested

Local change

Make sure to provide instructions for the maintainer as well as any relevant configurations.

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code

